### PR TITLE
Remove commons-collection + upgrade gradle.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -139,8 +139,6 @@ dependencies {
 
      compile 'commons-io:commons-io:2.4'
      compile 'org.apache.commons:commons-lang3:3.4'
-     compile 'commons-logging:commons-logging:1.1.3'
-     compile 'commons-collections:commons-collections:3.2.1'
      compile 'commons-codec:commons-codec:1.9'
 
     /*
@@ -282,7 +280,7 @@ install {
 }
 
 task wrapper(type: Wrapper) {
-    gradleVersion = '2.4'
+    gradleVersion = '2.5'
 }
 
 artifacts {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat May 30 18:11:06 PDT 2015
+#Sun Nov 08 17:50:08 PST 2015
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.5-bin.zip


### PR DESCRIPTION
Remove commons-collections library as it potential misuse can result in introduction or RCE vulnerabilities.