### PR TITLE
Use default type codec instance.

### DIFF
--- a/src/main/java/com/kryptnostic/rhizome/pods/CassandraPod.java
+++ b/src/main/java/com/kryptnostic/rhizome/pods/CassandraPod.java
@@ -59,7 +59,12 @@ public class CassandraPod {
 
     @Bean
     public CodecRegistry codecRegistry() {
-        CodecRegistry registry = new CodecRegistry();
+        /*
+         * We require all type codecs to be registered up front for automatic configuration. TypeCodec can be configured
+         * at a later time by inject the CodecRegistry being and calling CodecRegistry.register(...) If we don't use the
+         * 
+         */
+        CodecRegistry registry = cluster().getConfiguration().getCodecRegistry();
         if ( codecs != null ) {
             registry.register( codecs );
         }
@@ -73,7 +78,6 @@ public class CassandraPod {
                 .withPoolingOptions( getPoolingOptions() )
                 .withProtocolVersion( ProtocolVersion.NEWEST_SUPPORTED )
                 .addContactPoints( cassandraConfiguration().getCassandraSeedNodes() )
-                .withCodecRegistry( codecRegistry() )
                 .build();
     }
 

--- a/src/main/java/com/kryptnostic/rhizome/pods/CassandraPod.java
+++ b/src/main/java/com/kryptnostic/rhizome/pods/CassandraPod.java
@@ -59,6 +59,7 @@ public class CassandraPod {
 
     @Bean
     public CodecRegistry codecRegistry() {
+        //TODO: Explicitly construct default instance codecs so that not all sessions end up having all codecs. P2
         CodecRegistry registry = CodecRegistry.DEFAULT_INSTANCE;
         if ( codecs != null ) {
             registry.register( codecs );

--- a/src/main/java/com/kryptnostic/rhizome/pods/CassandraPod.java
+++ b/src/main/java/com/kryptnostic/rhizome/pods/CassandraPod.java
@@ -59,12 +59,7 @@ public class CassandraPod {
 
     @Bean
     public CodecRegistry codecRegistry() {
-        /*
-         * We require all type codecs to be registered up front for automatic configuration. TypeCodec can be configured
-         * at a later time by inject the CodecRegistry being and calling CodecRegistry.register(...) If we don't use the
-         * 
-         */
-        CodecRegistry registry = cluster().getConfiguration().getCodecRegistry();
+        CodecRegistry registry = CodecRegistry.DEFAULT_INSTANCE;
         if ( codecs != null ) {
             registry.register( codecs );
         }
@@ -78,6 +73,7 @@ public class CassandraPod {
                 .withPoolingOptions( getPoolingOptions() )
                 .withProtocolVersion( ProtocolVersion.NEWEST_SUPPORTED )
                 .addContactPoints( cassandraConfiguration().getCassandraSeedNodes() )
+                .withCodecRegistry( codecRegistry() )
                 .build();
     }
 


### PR DESCRIPTION
@makosblade Don't know if you were creating a new CodecRegistry on because you hit a conflict with existing codecs and our backend serializers. Not including the default codecs 

I've made it so that we're using the CodecRegistry.DEFAULT_INSTANCE and adding in additional codecs, instead of starting with a blank registry. 

If that is a problem, we'll have to come up with a better way for configuring codec registries.