### PR TITLE
Allow jwt token to be read from authorization cookie

### DIFF
--- a/src/main/java/digital/loom/rhizome/authentication/Auth0SecurityPod.java
+++ b/src/main/java/digital/loom/rhizome/authentication/Auth0SecurityPod.java
@@ -99,7 +99,7 @@ public class Auth0SecurityPod extends WebSecurityConfigurerAdapter {
     @Bean(
         name = "auth0Filter" )
     public Auth0AuthenticationFilter auth0AuthenticationFilter( final Auth0AuthenticationEntryPoint entryPoint ) {
-        final Auth0AuthenticationFilter filter = new Auth0AuthenticationFilter();
+        final Auth0AuthenticationFilter filter = new CookieReadingAuth0AuthenticationFilter();
         filter.setEntryPoint( entryPoint );
         return filter;
     }

--- a/src/main/java/digital/loom/rhizome/authentication/CookieReadingAuth0AuthenticationFilter.java
+++ b/src/main/java/digital/loom/rhizome/authentication/CookieReadingAuth0AuthenticationFilter.java
@@ -1,0 +1,39 @@
+package digital.loom.rhizome.authentication;
+
+import java.util.regex.Pattern;
+
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+
+import com.auth0.jwt.internal.org.apache.commons.lang3.StringUtils;
+import com.auth0.spring.security.api.Auth0AuthenticationFilter;
+import com.google.common.base.MoreObjects;
+
+public class CookieReadingAuth0AuthenticationFilter extends Auth0AuthenticationFilter {
+    @Override
+    protected String getToken( HttpServletRequest httpRequest ) {
+        String authorizationCookie = null;
+
+        for ( Cookie cookie : httpRequest.getCookies() ) {
+            if ( StringUtils.equals( cookie.getName(), "authorization" ) ) {
+                authorizationCookie = cookie.getValue();
+                break;
+            }
+        }
+
+        final String authorizationHeader = httpRequest.getHeader( "authorization" );
+        if ( authorizationHeader == null ) {
+            // "Unauthorized: No Authorization header was found"
+            return null;
+        }
+        final String[] parts = MoreObjects.firstNonNull( authorizationHeader, authorizationCookie ).split( " " );
+        if ( parts.length != 2 ) {
+            // "Unauthorized: Format is Authorization: Bearer [token]"
+            return null;
+        }
+        final String scheme = parts[ 0 ];
+        final String credentials = parts[ 1 ];
+        final Pattern pattern = Pattern.compile( "^Bearer$", Pattern.CASE_INSENSITIVE );
+        return pattern.matcher( scheme ).matches() ? credentials : null;
+    }
+}


### PR DESCRIPTION
@katherinebernstein You'll have to set the jwt token in bearer format for downloads to work properly-- I overlooked this.