### PR TITLE
fix loadall query for partition key value store

### DIFF
--- a/src/main/java/com/kryptnostic/rhizome/mapstores/cassandra/AbstractStructuredCassandraPartitionKeyValueStore.java
+++ b/src/main/java/com/kryptnostic/rhizome/mapstores/cassandra/AbstractStructuredCassandraPartitionKeyValueStore.java
@@ -1,5 +1,10 @@
 package com.kryptnostic.rhizome.mapstores.cassandra;
 
+import java.util.Collection;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.apache.commons.lang3.tuple.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -26,5 +31,16 @@ public abstract class AbstractStructuredCassandraPartitionKeyValueStore<K, V> ex
     @Override
     protected RegularStatement deleteQuery(){
         return tableBuilder.buildDeleteByPartitionKeyQuery();
+    }
+  
+    /**
+     * We assume that the (partition key)-value store has a unique value for each partition key. This has to be true for a (partition key)-value store to make sense.
+     */
+    @Override
+    public Map<K, V> loadAll( Collection<K> keys ) {
+        return keys.stream().map( k -> Pair.of( k, asyncLoad( k ) ) )
+                .map( p -> Pair.of( p.getLeft(), safeTransform( p.getRight() ) ) )
+                .filter( p -> p.getRight() != null )
+                .collect( Collectors.toMap( p -> p.getLeft(), p -> p.getRight(), (left, right) -> right ) );
     }
 }


### PR DESCRIPTION
Right now, loading the IMap `Securable_Object_Type` would fail at `loadAll` in `AbstractStructuredCassandraMapstoreBase`. This is because HashMap does not accept duplicate keys, and presumably duplicate keys occur because Hazelcast compares serialized byte version of keys rather than using equals method.

The fundamental assumption of a (partition key)-value store is that there is a unique value for each partition key. As long as this is true, the `loadAll` method in this PR should be safe.