### PR TITLE
Bugfix/backend 845

### DIFF
--- a/src/main/java/digital/loom/rhizome/authentication/Auth0SecurityPod.java
+++ b/src/main/java/digital/loom/rhizome/authentication/Auth0SecurityPod.java
@@ -12,6 +12,7 @@ import org.springframework.security.config.annotation.web.builders.WebSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.context.SecurityContextPersistenceFilter;
 
 import com.auth0.Auth0;
@@ -92,13 +93,13 @@ public class Auth0SecurityPod extends WebSecurityConfigurerAdapter {
     
     @Bean(
         name = "auth0EntryPoint" )
-    public Auth0AuthenticationEntryPoint auth0AuthenticationEntryPoint() {
+    public AuthenticationEntryPoint auth0AuthenticationEntryPoint() {
         return new Auth0AuthenticationEntryPoint();
     }
 
     @Bean(
         name = "auth0Filter" )
-    public Auth0AuthenticationFilter auth0AuthenticationFilter( final Auth0AuthenticationEntryPoint entryPoint ) {
+    public Auth0AuthenticationFilter auth0AuthenticationFilter( final AuthenticationEntryPoint entryPoint ) {
         final Auth0AuthenticationFilter filter = new CookieReadingAuth0AuthenticationFilter();
         filter.setEntryPoint( entryPoint );
         return filter;

--- a/src/test/java/digital/loom/rhizome/authentication/AuthenticationTest.java
+++ b/src/test/java/digital/loom/rhizome/authentication/AuthenticationTest.java
@@ -95,6 +95,11 @@ public class AuthenticationTest {
         return authentications.getUnchecked( authOptions );
     }
 
+    public static Authentication refreshAndGetAuthentication( AuthenticationTestRequestOptions options ) {
+        authentications.invalidate( options );
+        return authentications.getUnchecked( options );
+    }
+
     @Test
     public void testRoles() throws Exception {
         Authentication auth = authenticate();


### PR DESCRIPTION
Roles Service
- makes bean return `AuthenticationEntryPoint` rather than the subtype `Auth0AuthenticationEntryPoint` for easier overriding
- expose method in `AuthenticationTest` to refresh login, which is needed in `RolesServiceTest`