### PR TITLE
adjust rate limiter to make datastore test run

### DIFF
--- a/src/test/java/digital/loom/rhizome/authentication/AuthenticationTest.java
+++ b/src/test/java/digital/loom/rhizome/authentication/AuthenticationTest.java
@@ -70,7 +70,7 @@ public class AuthenticationTest {
             clientId,
             "loom.auth0.com" );
     private static final AuthenticationAPIClient client = auth0.newAuthenticationAPIClient();
-    private static final RateLimiter authRateLimiter = RateLimiter.create( 1.75 ); 
+    private static final RateLimiter authRateLimiter = RateLimiter.create( 0.25 ); 
     static {
         authentications = CacheBuilder.newBuilder()
                 .build( new CacheLoader<AuthenticationTestRequestOptions, Authentication>() {


### PR DESCRIPTION
just to be safe; an extra ~15s per test doesn't hurt